### PR TITLE
chore(gitignore): add ignore log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 dist
 dist-ssr
 *.local
+*.log


### PR DESCRIPTION
给.gitignore添加了*.log来忽视相关的本地log文件，比如yarn-error.log